### PR TITLE
chore: clean Either internal state

### DIFF
--- a/either.go
+++ b/either.go
@@ -9,26 +9,23 @@ var eitherMissingRightValue = fmt.Errorf("no such Right value")
 // Left builds the left side of the Either struct, as opposed to the Right side.
 func Left[L any, R any](value L) Either[L, R] {
 	return Either[L, R]{
-		isLeft:  true,
-		isRight: false,
-		left:    value,
+		isLeft: true,
+		left:   value,
 	}
 }
 
 // Right builds the right side of the Either struct, as opposed to the Left side.
 func Right[L any, R any](value R) Either[L, R] {
 	return Either[L, R]{
-		isLeft:  false,
-		isRight: true,
-		right:   value,
+		isLeft: false,
+		right:  value,
 	}
 }
 
 // Either respresents a value of 2 possible types.
 // An instance of Either is an instance of either A or B.
 type Either[L any, R any] struct {
-	isLeft  bool
-	isRight bool
+	isLeft bool
 
 	left  L
 	right R
@@ -41,12 +38,12 @@ func (e Either[L, R]) IsLeft() bool {
 
 // IsRight returns true if Either is an instance of Right.
 func (e Either[L, R]) IsRight() bool {
-	return e.isRight
+	return !e.isLeft
 }
 
 // Left returns left value of a Either struct.
 func (e Either[L, R]) Left() (L, bool) {
-	if e.isLeft {
+	if e.IsLeft() {
 		return e.left, true
 	}
 	return empty[L](), false
@@ -54,7 +51,7 @@ func (e Either[L, R]) Left() (L, bool) {
 
 // Right returns right value of a Either struct.
 func (e Either[L, R]) Right() (R, bool) {
-	if e.isRight {
+	if e.IsRight() {
 		return e.right, true
 	}
 	return empty[R](), false
@@ -62,7 +59,7 @@ func (e Either[L, R]) Right() (R, bool) {
 
 // MustLeft returns left value of a Either struct or panics.
 func (e Either[L, R]) MustLeft() L {
-	if !e.isLeft {
+	if !e.IsLeft() {
 		panic(eitherMissingLeftValue)
 	}
 
@@ -71,7 +68,7 @@ func (e Either[L, R]) MustLeft() L {
 
 // MustRight returns right value of a Either struct or panics.
 func (e Either[L, R]) MustRight() R {
-	if !e.isRight {
+	if !e.IsRight() {
 		panic(eitherMissingRightValue)
 	}
 
@@ -80,7 +77,7 @@ func (e Either[L, R]) MustRight() R {
 
 // LeftOrElse returns left value of a Either struct or fallback.
 func (e Either[L, R]) LeftOrElse(fallback L) L {
-	if e.isLeft {
+	if e.IsLeft() {
 		return e.left
 	}
 
@@ -89,7 +86,7 @@ func (e Either[L, R]) LeftOrElse(fallback L) L {
 
 // RightOrElse returns right value of a Either struct or fallback.
 func (e Either[L, R]) RightOrElse(fallback R) R {
-	if e.isRight {
+	if e.IsRight() {
 		return e.right
 	}
 
@@ -98,7 +95,7 @@ func (e Either[L, R]) RightOrElse(fallback R) R {
 
 // LeftOrEmpty returns left value of a Either struct or empty value.
 func (e Either[L, R]) LeftOrEmpty() L {
-	if e.isLeft {
+	if e.IsLeft() {
 		return e.left
 	}
 
@@ -107,7 +104,7 @@ func (e Either[L, R]) LeftOrEmpty() L {
 
 // RightOrEmpty returns right value of a Either struct or empty value.
 func (e Either[L, R]) RightOrEmpty() R {
-	if e.isRight {
+	if e.IsRight() {
 		return e.right
 	}
 
@@ -116,7 +113,7 @@ func (e Either[L, R]) RightOrEmpty() R {
 
 // Swap returns the left value in Right and vice versa.
 func (e Either[L, R]) Swap() Either[R, L] {
-	if e.isLeft {
+	if e.IsLeft() {
 		return Right[R, L](e.left)
 	}
 
@@ -125,18 +122,18 @@ func (e Either[L, R]) Swap() Either[R, L] {
 
 // ForEach executes the given side-effecting function, depending of value is Left or Right.
 func (e Either[L, R]) ForEach(leftCb func(L), rightCb func(R)) {
-	if e.isLeft {
+	if e.IsLeft() {
 		leftCb(e.left)
-	} else if e.isRight {
+	} else if e.IsRight() {
 		rightCb(e.right)
 	}
 }
 
 // Match executes the given function, depending of value is Left or Right, and returns result.
 func (e Either[L, R]) Match(onLeft func(L) Either[L, R], onRight func(R) Either[L, R]) Either[L, R] {
-	if e.isLeft {
+	if e.IsLeft() {
 		return onLeft(e.left)
-	} else if e.isRight {
+	} else if e.IsRight() {
 		return onRight(e.right)
 	}
 
@@ -145,9 +142,9 @@ func (e Either[L, R]) Match(onLeft func(L) Either[L, R], onRight func(R) Either[
 
 // MapLeft executes the given function, if Either is of type Left, and returns result.
 func (e Either[L, R]) MapLeft(mapper func(L) Either[L, R]) Either[L, R] {
-	if e.isLeft {
+	if e.IsLeft() {
 		return mapper(e.left)
-	} else if e.isRight {
+	} else if e.IsRight() {
 		return Right[L, R](e.right)
 	}
 
@@ -158,7 +155,7 @@ func (e Either[L, R]) MapLeft(mapper func(L) Either[L, R]) Either[L, R] {
 func (e Either[L, R]) MapRight(mapper func(R) Either[L, R]) Either[L, R] {
 	if e.isLeft {
 		return Left[L, R](e.left)
-	} else if e.isRight {
+	} else if e.IsRight() {
 		return mapper(e.right)
 	}
 

--- a/either_test.go
+++ b/either_test.go
@@ -10,14 +10,14 @@ func TestEitherLeft(t *testing.T) {
 	is := assert.New(t)
 
 	left := Left[int, bool](42)
-	is.Equal(Either[int, bool]{left: 42, right: false, isLeft: true, isRight: false}, left)
+	is.Equal(Either[int, bool]{left: 42, right: false, isLeft: true}, left)
 }
 
 func TestEitherRight(t *testing.T) {
 	is := assert.New(t)
 
 	right := Right[int, bool](true)
-	is.Equal(Either[int, bool]{left: 0, right: true, isLeft: false, isRight: true}, right)
+	is.Equal(Either[int, bool]{left: 0, right: true, isLeft: false}, right)
 }
 
 func TestEitherIsLeftOrRight(t *testing.T) {
@@ -103,8 +103,8 @@ func TestEitherSwap(t *testing.T) {
 	left := Left[int, string](42)
 	right := Right[int, string]("foobar")
 
-	is.Equal(Either[string, int]{left: "", right: 42, isLeft: false, isRight: true}, left.Swap())
-	is.Equal(Either[string, int]{left: "foobar", right: 0, isLeft: true, isRight: false}, right.Swap())
+	is.Equal(Either[string, int]{left: "", right: 42, isLeft: false}, left.Swap())
+	is.Equal(Either[string, int]{left: "foobar", right: 0, isLeft: true}, right.Swap())
 }
 
 func TestEitherForEach(t *testing.T) {
@@ -154,8 +154,8 @@ func TestEitherMatch(t *testing.T) {
 		},
 	)
 
-	is.Equal(Either[int, string]{left: 21, right: "", isLeft: true, isRight: false}, e1)
-	is.Equal(Either[int, string]{left: 0, right: "plop", isLeft: false, isRight: true}, e2)
+	is.Equal(Either[int, string]{left: 21, right: "", isLeft: true}, e1)
+	is.Equal(Either[int, string]{left: 0, right: "plop", isLeft: false}, e2)
 }
 
 func TestEitherMapLeft(t *testing.T) {
@@ -175,8 +175,8 @@ func TestEitherMapLeft(t *testing.T) {
 		},
 	)
 
-	is.Equal(Either[int, string]{left: 21, right: "", isLeft: true, isRight: false}, e1)
-	is.Equal(Either[int, string]{left: 0, right: "foobar", isLeft: false, isRight: true}, e2)
+	is.Equal(Either[int, string]{left: 21, right: "", isLeft: true}, e1)
+	is.Equal(Either[int, string]{left: 0, right: "foobar", isLeft: false}, e2)
 }
 
 func TestEitherMapRight(t *testing.T) {
@@ -196,6 +196,6 @@ func TestEitherMapRight(t *testing.T) {
 		},
 	)
 
-	is.Equal(Either[int, string]{left: 42, right: "", isLeft: true, isRight: false}, e1)
-	is.Equal(Either[int, string]{left: 0, right: "plop", isLeft: false, isRight: true}, e2)
+	is.Equal(Either[int, string]{left: 42, right: "", isLeft: true}, e1)
+	is.Equal(Either[int, string]{left: 0, right: "plop", isLeft: false}, e2)
 }

--- a/io_either_test.go
+++ b/io_either_test.go
@@ -16,7 +16,7 @@ func TestIOEither(t *testing.T) {
 
 	is.False(result.isLeft)
 	is.Nil(result.Left())
-	is.True(result.isRight)
+	is.True(result.IsRight())
 	is.Equal(42, result.MustRight())
 }
 
@@ -31,7 +31,7 @@ func TestIOEither1(t *testing.T) {
 
 	is.False(result.isLeft)
 	is.Nil(result.Left())
-	is.True(result.isRight)
+	is.True(result.IsRight())
 	is.Equal(42, result.MustRight())
 }
 
@@ -47,7 +47,7 @@ func TestIOEither2(t *testing.T) {
 
 	is.False(result.isLeft)
 	is.Nil(result.Left())
-	is.True(result.isRight)
+	is.True(result.IsRight())
 	is.Equal(42, result.MustRight())
 }
 
@@ -64,7 +64,7 @@ func TestIOEither3(t *testing.T) {
 
 	is.False(result.isLeft)
 	is.Nil(result.Left())
-	is.True(result.isRight)
+	is.True(result.IsRight())
 	is.Equal(42, result.MustRight())
 }
 
@@ -82,7 +82,7 @@ func TestIOEither4(t *testing.T) {
 
 	is.False(result.isLeft)
 	is.Nil(result.Left())
-	is.True(result.isRight)
+	is.True(result.IsRight())
 	is.Equal(42, result.MustRight())
 }
 
@@ -101,6 +101,6 @@ func TestIOEither5(t *testing.T) {
 
 	is.False(result.isLeft)
 	is.Nil(result.Left())
-	is.True(result.isRight)
+	is.True(result.IsRight())
 	is.Equal(42, result.MustRight())
 }


### PR DESCRIPTION
Currently, the Either struct uses two booleans to represent what kind of value we have.
Even though `mo` doesn't export these booleans, they allow for 4 different states instead of the desired 2. This PR removes the `isRight` boolean, enforcing only two possible states can be represented internally.
This change has the benefit of simplifying some tests, albeit very minimally.