### PR TITLE
Option: Add PointerOrNil

### DIFF
--- a/option.go
+++ b/option.go
@@ -172,7 +172,7 @@ func (o Option[T]) FlatMap(mapper func(value T) Option[T]) Option[T] {
 	return None[T]()
 }
 
-// OrNil returns value if present or a nil pointer.
+// PointerOrNil returns value if present or a nil pointer.
 // Play: TODO
 func (o Option[T]) PointerOrNil() *T {
 	if !o.isPresent {

--- a/option.go
+++ b/option.go
@@ -172,6 +172,16 @@ func (o Option[T]) FlatMap(mapper func(value T) Option[T]) Option[T] {
 	return None[T]()
 }
 
+// OrNil returns value if present or a nil pointer.
+// Play: TODO
+func (o Option[T]) PointerOrNil() *T {
+	if !o.isPresent {
+		return nil
+	}
+
+	return &o.value
+}
+
 // MarshalJSON encodes Option into json.
 func (o Option[T]) MarshalJSON() ([]byte, error) {
 	if o.isPresent {

--- a/option_test.go
+++ b/option_test.go
@@ -115,6 +115,16 @@ func TestOptionOrEmpty(t *testing.T) {
 	is.Equal(0, None[int]().OrEmpty())
 }
 
+func TestOptionPointerOrNil(t *testing.T) {
+	is := assert.New(t)
+
+	p := Some(42).PointerOrNil()
+	is.NotNil(p)
+	is.Equal(42, *p)
+
+	is.Nil(None[int]().PointerOrNil())
+}
+
 func TestOptionForEach(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
Hey, thanks for the project!

One thing I missed when working with `Option` is to convert it to a pointer easily. It's like the opposite of `PointerToOption`.

It would be useful when converting values for structs used for marshaling. In my case, it's OpenAPI-generated structs with fields like `*string`, etc.

If you like the idea, I'll add examples and docs.