### PR TITLE
fix: driver.Valuer implementation on Option

### DIFF
--- a/option.go
+++ b/option.go
@@ -305,6 +305,5 @@ func (o Option[T]) Value() (driver.Value, error) {
 	if !o.isPresent {
 		return nil, nil
 	}
-
-	return o.value, nil
+	return driver.DefaultParameterConverter.ConvertValue(o.value)
 }


### PR DESCRIPTION
I encountered a bug where the driver couldn't derive the type of `Option[uint32]`. Go has `driver.DefaultParameterConverter` that returns the correct `Value`, therefore I delegated the `Option.Value` method to `driver.DefaultParameterConverter.ConvertValue`