### PR TITLE
Fix function Map for Option type

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ option1.
     FlatMap(func (value int) Option[int] {
         return Some(value%2)
     }).
-    FlatMap(func (value int) Option[int] {
-        return Some(value+21)
+    Map(func (value int) int {
+        return value+21
     }).
     OrElse(1234)
 // 21

--- a/option.go
+++ b/option.go
@@ -143,13 +143,12 @@ func (o Option[T]) Match(onValue func(value T) (T, bool), onNone func() (T, bool
 	return TupleToOption(onNone())
 }
 
-// Map executes the mapper function if value is present or returns None if absent.
-// Play: https://go.dev/play/p/mvfP3pcP_eJ
-func (o Option[T]) Map(mapper func(value T) (T, bool)) Option[T] {
+// Map executes the mapper function for a value.
+// Play: https://go.dev/play/p/-A5IMTdRLI-
+func (o Option[T]) Map(mapper func(value T) T) Option[T] {
 	if o.isPresent {
-		return TupleToOption(mapper(o.value))
+		return Some(mapper(o.value))
 	}
-
 	return None[T]()
 }
 

--- a/option_example_test.go
+++ b/option_example_test.go
@@ -240,8 +240,8 @@ func ExampleOption_Match_none() {
 
 func ExampleOption_Map_some() {
 	some := Some(42)
-	result := some.Map(func(i int) (int, bool) {
-		return 1234, true
+	result := some.Map(func(i int) int {
+		return 1234
 	})
 
 	fmt.Println(result.IsPresent(), result.OrEmpty())
@@ -250,8 +250,8 @@ func ExampleOption_Map_some() {
 
 func ExampleOption_Map_none() {
 	none := None[int]()
-	result := none.Map(func(i int) (int, bool) {
-		return 1234, true
+	result := none.Map(func(i int) int {
+		return 1234
 	})
 
 	fmt.Println(result.IsPresent(), result.OrEmpty())

--- a/option_test.go
+++ b/option_test.go
@@ -161,12 +161,12 @@ func TestOptionMatch(t *testing.T) {
 func TestOptionMap(t *testing.T) {
 	is := assert.New(t)
 
-	opt1 := Some(21).Map(func(i int) (int, bool) {
-		return i * 2, true
+	opt1 := Some(21).Map(func(i int) int {
+		return i * 2
 	})
-	opt2 := None[int]().Map(func(i int) (int, bool) {
+	opt2 := None[int]().Map(func(i int) int {
 		is.Fail("should not be called")
-		return 42, true
+		return 42
 	})
 
 	is.Equal(Option[int]{value: 42, isPresent: true}, opt1)


### PR DESCRIPTION
After the first touch of `Option` type I was confused how the `Map` function is implemented. 

In my understanding of functional programming the `Map` function should be applied only for a value and return the value, and never return the no-value.

For case when need to apply function for a value and return `Some` or `None` the `FlatMap` function should be used.

Before:
```scala
Some(1).
  Map(func(value int) (int, bool) {
    return value + 21, true
  })
```

After:
```scala
Some(1).
  Map(func(value int) int {
    return value + 21
  })
```