### PR TITLE
Add Fold function to Result monad

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
           stable: false
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
           args: --timeout 120s --max-same-issues 50

--- a/either.go
+++ b/either.go
@@ -166,3 +166,18 @@ func (e Either[L, R]) MapRight(mapper func(R) Either[L, R]) Either[L, R] {
 
 	panic(eitherShouldBeLeftOrRight)
 }
+
+// leftValue returns left value of a Either struct.(implementation of Foldable interface)
+func (e Either[L, R]) leftValue() L {
+	return e.left
+}
+
+// rightValue returns right value of a Either struct.(implementation of Foldable interface)
+func (e Either[L, R]) rightValue() R {
+	return e.right
+}
+
+// hasLeft returns true if the Result represents an error state.
+func (e Either[L, R]) hasLeftValue() bool {
+	return e.isLeft
+}

--- a/either_test.go
+++ b/either_test.go
@@ -1,6 +1,8 @@
 package mo
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -210,4 +212,42 @@ func TestEitherMapRight(t *testing.T) {
 
 	is.Equal(Either[int, string]{left: 42, right: "", isLeft: true}, e1)
 	is.Equal(Either[int, string]{left: 0, right: "plop", isLeft: false}, e2)
+}
+
+// TestEitherFoldSuccess tests the Fold method with a successful result.
+func TestEitherFoldSuccess(t *testing.T) {
+	is := assert.New(t)
+	either := Either[error, int]{left: nil, right: 10, isLeft: false}
+
+	successFunc := func(value int) string {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) string {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := Fold[error, int, string](either, successFunc, failureFunc)
+	expected := "Success: 10"
+
+	is.Equal(expected, folded)
+}
+
+// TestEitherFoldFailure tests the Fold method with a failure result.
+func TestEitherFoldFailure(t *testing.T) {
+	err := errors.New("result error")
+	is := assert.New(t)
+
+	either := Either[error, int]{left: err, right: 0, isLeft: true}
+
+	successFunc := func(value int) string {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) string {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := Fold[error, int, string](either, successFunc, failureFunc)
+	expected := fmt.Sprintf("Failure: %v", err)
+
+	is.Equal(expected, folded)
 }

--- a/fold.go
+++ b/fold.go
@@ -12,9 +12,6 @@ type Foldable[T any, U any] interface {
 }
 
 // Fold applies one of the two functions based on the state of the Foldable type,
-// and returns the result of applying that function.
-
-// Fold applies one of the two functions based on the state of the Foldable type,
 // and it returns the result of applying either successFunc or failureFunc.
 //
 // - T: the type of the failure value (e.g., an error type)

--- a/fold.go
+++ b/fold.go
@@ -6,9 +6,9 @@ package mo
 // - T: the type of the value in the failure state (e.g., an error type).
 // - U: the type of the value in the success state.
 type Foldable[T any, U any] interface {
-	left() T
-	right() U
-	isLeft() bool
+	leftValue() T
+	rightValue() U
+	hasLeftValue() bool
 }
 
 // Fold applies one of the two functions based on the state of the Foldable type,
@@ -21,8 +21,8 @@ type Foldable[T any, U any] interface {
 // successFunc is applied when the Foldable is in the success state (i.e., isLeft() is false).
 // failureFunc is applied when the Foldable is in the failure state (i.e., isLeft() is true).
 func Fold[T, U, R any](f Foldable[T, U], successFunc func(U) R, failureFunc func(T) R) R {
-	if f.isLeft() {
-		return failureFunc(f.left())
+	if f.hasLeftValue() {
+		return failureFunc(f.leftValue())
 	}
-	return successFunc(f.right())
+	return successFunc(f.rightValue())
 }

--- a/fold.go
+++ b/fold.go
@@ -1,0 +1,31 @@
+package mo
+
+// Foldable represents a type that can be folded into a single value
+// based on its state.
+//
+// - T: the type of the value in the failure state (e.g., an error type).
+// - U: the type of the value in the success state.
+type Foldable[T any, U any] interface {
+	left() T
+	right() U
+	isLeft() bool
+}
+
+// Fold applies one of the two functions based on the state of the Foldable type,
+// and returns the result of applying that function.
+
+// Fold applies one of the two functions based on the state of the Foldable type,
+// and it returns the result of applying either successFunc or failureFunc.
+//
+// - T: the type of the failure value (e.g., an error type)
+// - U: the type of the success value
+// - R: the type of the return value from the folding functions
+//
+// successFunc is applied when the Foldable is in the success state (i.e., isLeft() is false).
+// failureFunc is applied when the Foldable is in the failure state (i.e., isLeft() is true).
+func Fold[T, U, R any](f Foldable[T, U], successFunc func(U) R, failureFunc func(T) R) R {
+	if f.isLeft() {
+		return failureFunc(f.left())
+	}
+	return successFunc(f.right())
+}

--- a/option.go
+++ b/option.go
@@ -309,16 +309,16 @@ func (o Option[T]) Value() (driver.Value, error) {
 	return o.value, nil
 }
 
-// left returns an error if the Option is None, otherwise nil
-func (o Option[T]) left() error {
+// leftValue returns an error if the Option is None, otherwise nil
+func (o Option[T]) leftValue() error {
 	if !o.isPresent {
 		return optionNoSuchElement
 	}
 	return nil
 }
 
-// right returns the value if the Option is Some, otherwise the zero value of T
-func (o Option[T]) right() T {
+// rightValue returns the value if the Option is Some, otherwise the zero value of T
+func (o Option[T]) rightValue() T {
 	if !o.isPresent {
 		var zero T
 		return zero
@@ -326,7 +326,7 @@ func (o Option[T]) right() T {
 	return o.value
 }
 
-// isLeft returns true if the Option represents a None state
-func (o Option[T]) isLeft() bool {
+// hasLeftValue returns true if the Option represents a None state
+func (o Option[T]) hasLeftValue() bool {
 	return !o.isPresent
 }

--- a/option.go
+++ b/option.go
@@ -308,3 +308,25 @@ func (o Option[T]) Value() (driver.Value, error) {
 
 	return o.value, nil
 }
+
+// left returns an error if the Option is None, otherwise nil
+func (o Option[T]) left() error {
+	if !o.isPresent {
+		return optionNoSuchElement
+	}
+	return nil
+}
+
+// right returns the value if the Option is Some, otherwise the zero value of T
+func (o Option[T]) right() T {
+	if !o.isPresent {
+		var zero T
+		return zero
+	}
+	return o.value
+}
+
+// isLeft returns true if the Option represents a None state
+func (o Option[T]) isLeft() bool {
+	return !o.isPresent
+}

--- a/option_test.go
+++ b/option_test.go
@@ -463,3 +463,39 @@ func TestOptionScanner(t *testing.T) {
 	is.NoError(err2)
 	is.EqualValues(None[SomeScanner](), noneScanner)
 }
+
+// TestOptionFoldSuccess tests the Fold method with a successful result.
+func TestOptionFoldSuccess(t *testing.T) {
+	is := assert.New(t)
+	option := Option[int]{isPresent: true, value: 10}
+
+	successFunc := func(value int) string {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) string {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := Fold[error, int, string](option, successFunc, failureFunc)
+	expected := "Success: 10"
+
+	is.Equal(expected, folded)
+}
+
+// // TestOptionFoldFailure tests the Fold method with a failure result.
+func TestOptionFoldFailure(t *testing.T) {
+	is := assert.New(t)
+	option := Option[int]{isPresent: false}
+
+	successFunc := func(value int) string {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) string {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := Fold[error, int, string](option, successFunc, failureFunc)
+	expected := fmt.Sprintf("Failure: %v", optionNoSuchElement)
+
+	is.Equal(expected, folded)
+}

--- a/result.go
+++ b/result.go
@@ -137,6 +137,8 @@ func (r Result[T]) Match(onSuccess func(value T) (T, error), onError func(err er
 	return TupleToResult(onSuccess(r.value))
 }
 
+// Fold applies one of the two functions based on whether the result is a success or failure,
+// and returns the result of applying that function.
 func (r Result[T]) Fold(successFunc func(T) interface{}, failureFunc func(error) interface{}) interface{} {
 	if r.err != nil {
 		return failureFunc(r.err)

--- a/result.go
+++ b/result.go
@@ -137,6 +137,13 @@ func (r Result[T]) Match(onSuccess func(value T) (T, error), onError func(err er
 	return TupleToResult(onSuccess(r.value))
 }
 
+func (r Result[T]) Fold(successFunc func(T) interface{}, failureFunc func(error) interface{}) interface{} {
+	if r.err != nil {
+		return failureFunc(r.err)
+	}
+	return successFunc(r.value)
+}
+
 // Map executes the mapper function if Result is valid. It returns a new Result.
 // Play: https://go.dev/play/p/-ndpN_b_OSc
 func (r Result[T]) Map(mapper func(value T) (T, error)) Result[T] {

--- a/result.go
+++ b/result.go
@@ -214,17 +214,17 @@ func (o *Result[T]) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-// left returns the error if the Result is an error, otherwise nil
-func (r Result[T]) left() error {
+// leftValue returns the error if the Result is an error, otherwise nil
+func (r Result[T]) leftValue() error {
 	return r.err
 }
 
-// right returns the value if the Result is a success, otherwise the zero value of T
-func (r Result[T]) right() T {
+// rightValue returns the value if the Result is a success, otherwise the zero value of T
+func (r Result[T]) rightValue() T {
 	return r.value
 }
 
-// isLeft returns true if the Result represents an error state.
-func (r Result[T]) isLeft() bool {
+// hasLeftValue returns true if the Result represents an error state.
+func (r Result[T]) hasLeftValue() bool {
 	return r.isErr
 }

--- a/result.go
+++ b/result.go
@@ -137,15 +137,6 @@ func (r Result[T]) Match(onSuccess func(value T) (T, error), onError func(err er
 	return TupleToResult(onSuccess(r.value))
 }
 
-// Fold applies one of the two functions based on whether the result is a success or failure,
-// and returns the result of applying that function.
-func (r Result[T]) Fold(successFunc func(T) interface{}, failureFunc func(error) interface{}) interface{} {
-	if r.err != nil {
-		return failureFunc(r.err)
-	}
-	return successFunc(r.value)
-}
-
 // Map executes the mapper function if Result is valid. It returns a new Result.
 // Play: https://go.dev/play/p/-ndpN_b_OSc
 func (r Result[T]) Map(mapper func(value T) (T, error)) Result[T] {
@@ -221,4 +212,19 @@ func (o *Result[T]) UnmarshalJSON(data []byte) error {
 	o.value = result.Result
 	o.isErr = false
 	return nil
+}
+
+// left returns the error if the Result is an error, otherwise nil
+func (r Result[T]) left() error {
+	return r.err
+}
+
+// right returns the value if the Result is a success, otherwise the zero value of T
+func (r Result[T]) right() T {
+	return r.value
+}
+
+// isLeft returns true if the Result represents an error state.
+func (r Result[T]) isLeft() bool {
+	return r.isErr
 }

--- a/result_example_test.go
+++ b/result_example_test.go
@@ -346,3 +346,13 @@ func ExampleResult_FlatMap_err() {
 	fmt.Println(result.IsError(), result.OrEmpty(), result.Error())
 	// Output: true 0 error
 }
+
+func exampleResult_Fold() {
+	res := Result[int]{value: 42, err: nil}
+	foldResult := Fold[error, int, string](res, func(v int) string {
+		return "Success"
+	}, func(_ error) string {
+		return "Failure"
+	})
+	println(foldResult)
+}

--- a/result_test.go
+++ b/result_test.go
@@ -163,14 +163,14 @@ func TestResultMatch(t *testing.T) {
 func TestFoldSuccess(t *testing.T) {
 	result := Result[int]{value: 42, isErr: false, err: nil}
 
-	successFunc := func(value int) interface{} {
+	successFunc := func(value int) string {
 		return fmt.Sprintf("Success: %v", value)
 	}
-	failureFunc := func(err error) interface{} {
+	failureFunc := func(err error) string {
 		return fmt.Sprintf("Failure: %v", err)
 	}
 
-	folded := result.Fold(successFunc, failureFunc)
+	folded := Fold[error, int, string](result, successFunc, failureFunc)
 	expected := "Success: 42"
 
 	if folded != expected {
@@ -183,17 +183,17 @@ func TestFoldFailure(t *testing.T) {
 	expectedError := assert.AnError
 	result := Result[int]{value: 0, isErr: true, err: expectedError}
 
-	successFunc := func(value int) interface{} {
+	successFunc := func(value int) string {
 		return fmt.Sprintf("Success: %v", value)
 	}
-	failureFunc := func(err error) interface{} {
+	failureFunc := func(err error) string {
 		if err == expectedError {
 			return "Expected error occurred"
 		}
 		return fmt.Sprintf("Failure: %v", err)
 	}
 
-	folded := result.Fold(successFunc, failureFunc)
+	folded := Fold[error, int, string](result, successFunc, failureFunc)
 	expected := "Expected error occurred"
 
 	assert.Equal(t, expected, folded)

--- a/result_test.go
+++ b/result_test.go
@@ -2,6 +2,7 @@ package mo
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -159,46 +160,6 @@ func TestResultMatch(t *testing.T) {
 	is.Equal(Result[int]{value: 0, isErr: true, err: assert.AnError}, opt2)
 }
 
-// TestFoldSuccess tests the Fold method with a successful result.
-func TestFoldSuccess(t *testing.T) {
-	result := Result[int]{value: 42, isErr: false, err: nil}
-
-	successFunc := func(value int) string {
-		return fmt.Sprintf("Success: %v", value)
-	}
-	failureFunc := func(err error) string {
-		return fmt.Sprintf("Failure: %v", err)
-	}
-
-	folded := Fold[error, int, string](result, successFunc, failureFunc)
-	expected := "Success: 42"
-
-	if folded != expected {
-		t.Errorf("Expected %q, got %q", expected, folded)
-	}
-}
-
-// TestFoldFailure tests the Fold method with a failure result.
-func TestFoldFailure(t *testing.T) {
-	expectedError := assert.AnError
-	result := Result[int]{value: 0, isErr: true, err: expectedError}
-
-	successFunc := func(value int) string {
-		return fmt.Sprintf("Success: %v", value)
-	}
-	failureFunc := func(err error) string {
-		if err == expectedError {
-			return "Expected error occurred"
-		}
-		return fmt.Sprintf("Failure: %v", err)
-	}
-
-	folded := Fold[error, int, string](result, successFunc, failureFunc)
-	expected := "Expected error occurred"
-
-	assert.Equal(t, expected, folded)
-}
-
 func TestResultMap(t *testing.T) {
 	is := assert.New(t)
 
@@ -333,4 +294,42 @@ func TestResultUnmarshalJSON(t *testing.T) {
 	unmarshal = testStruct{}
 	err = json.Unmarshal([]byte(`{"Field": "}`), &unmarshal)
 	is.Error(err)
+}
+
+// TestResultFoldSuccess tests the Fold method with a successful result.
+func TestResultFoldSuccess(t *testing.T) {
+	is := assert.New(t)
+	result := Result[int]{value: 42, isErr: false, err: nil}
+
+	successFunc := func(value int) string {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) string {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := Fold[error, int, string](result, successFunc, failureFunc)
+	expected := "Success: 42"
+
+	is.Equal(expected, folded)
+}
+
+// TestResultFoldFailure tests the Fold method with a failure result.
+func TestResultFoldFailure(t *testing.T) {
+	err := errors.New("result error")
+	is := assert.New(t)
+
+	result := Result[int]{value: 0, isErr: true, err: err}
+
+	successFunc := func(value int) string {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) string {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := Fold[error, int, string](result, successFunc, failureFunc)
+	expected := fmt.Sprintf("Failure: %v", err)
+
+	is.Equal(expected, folded)
 }

--- a/result_test.go
+++ b/result_test.go
@@ -159,6 +159,46 @@ func TestResultMatch(t *testing.T) {
 	is.Equal(Result[int]{value: 0, isErr: true, err: assert.AnError}, opt2)
 }
 
+// TestFoldSuccess tests the Fold method with a successful result.
+func TestFoldSuccess(t *testing.T) {
+	result := Result[int]{value: 42, isErr: false, err: nil}
+
+	successFunc := func(value int) interface{} {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) interface{} {
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := result.Fold(successFunc, failureFunc)
+	expected := "Success: 42"
+
+	if folded != expected {
+		t.Errorf("Expected %q, got %q", expected, folded)
+	}
+}
+
+// TestFoldFailure tests the Fold method with a failure result.
+func TestFoldFailure(t *testing.T) {
+	expectedError := assert.AnError
+	result := Result[int]{value: 0, isErr: true, err: expectedError}
+
+	successFunc := func(value int) interface{} {
+		return fmt.Sprintf("Success: %v", value)
+	}
+	failureFunc := func(err error) interface{} {
+		if err == expectedError {
+			return "Expected error occurred"
+		}
+		return fmt.Sprintf("Failure: %v", err)
+	}
+
+	folded := result.Fold(successFunc, failureFunc)
+	expected := "Expected error occurred"
+
+	assert.Equal(t, expected, folded)
+}
+
 func TestResultMap(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
This pull request introduces `Fold` function to the `Result` monad, enhancing its functionality and making it more versatile for handling both success and failure scenarios.

### Changes Made:
- Implemented a `Fold` function within the `Result` monad, allowing for streamlined handling of success and failure cases.
- The `Fold` function takes two callback functions as arguments:
  - `successFunc`: A function to be applied if the `Result` contains a successful value. It transforms the value into another type.
  - `failureFunc`: A function to be applied if the `Result` contains an error. It transforms the error into another type.
- If the `Result` contains an error, the `Fold` function applies the `failureFunc` to the error and returns the transformed result.
- If the `Result` contains a successful value, the `Fold` function applies the `successFunc` to the value and returns the transformed result.

### Benefits:
- Provides a clean and declarative way to handle both success and failure cases within the `Result` monad.
- Increases the versatility and usability of the `Result` monad by enabling developers to easily define custom behavior for different scenarios.
- Enhances code readability and maintainability by encapsulating error-handling logic within the `Result` monad itself.

### Example:
```golang
func main() {
	result := maySucceed(5)

	foldResult := result.Fold(onSuccess, onFailure)
	fmt.Println(foldResult)
}

func maySucceed(value int) mo.Result[int] {
	if value < 0 {
		return mo.Err[int](errors.New("Value must be greater than 0"))
	}

	return mo.Ok(value)
}

func onSuccess(value int) interface{} {
	return fmt.Sprintf("Success: %v", value)
}

func onFailure(err error) interface{} {
	return fmt.Sprintf("Failure: %v", err)
}

```