### PR TITLE
Downgrade the goleak version to one that is compatible with the go version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,6 @@ jobs:
           stable: false
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v5
+        uses: golangci/golangci-lint-action@v6
         with:
           args: --timeout 120s --max-same-issues 50

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ go 1.18
 
 require (
 	github.com/stretchr/testify v1.9.0
-	go.uber.org/goleak v1.3.0
+	go.uber.org/goleak v1.2.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
-go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/goleak v1.2.1 h1:NBol2c7O1ZokfZ0LEU9K6Whx/KnwvepVetCUhtKja4A=
+go.uber.org/goleak v1.2.1/go.mod h1:qlT2yGI9QafXHhZZLxlSuNsMw3FFLxBr+tBRlmO1xH4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=


### PR DESCRIPTION
The Golang version, along with some dependencies, has been upgraded [here](https://github.com/samber/mo/commit/1e53522418069311fb786ab15d763609d34546f1#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R5). However, in a later commit, the Golang version was [downgraded again to 1.18](https://github.com/samber/mo/commit/47435930f4e463dce153a6ca7acbc37e903bdbb6#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R3) without the dependencies.

Currently, the CI will fail when running tests due to this error

```
# go.uber.org/goleak/internal/stack
../../../.asdf/installs/golang/1.18/packages/pkg/mod/go.uber.org/goleak@v1.3.0/internal/stack/stacks.go:123:26: undefined: errors.Join
../../../.asdf/installs/golang/1.18/packages/pkg/mod/go.uber.org/goleak@v1.3.0/internal/stack/stacks.go:256:26: undefined: strings.CutPrefix
note: module requires Go 1.20
```