### PR TITLE
Add ErrContext method to Result

### DIFF
--- a/result.go
+++ b/result.go
@@ -157,6 +157,14 @@ func (r Result[T]) MapErr(mapper func(error) (T, error)) Result[T] {
 	return Ok(r.value)
 }
 
+func (r Result[T]) ErrContext(context string) Result[T] {
+	if r.isErr {
+		return Err[T](fmt.Errorf("%s\n\nOriginal Error:\n%s", context, r.err.Error()))
+	}
+
+	return Ok(r.value)
+}
+
 // FlatMap executes the mapper function if Result is valid. It returns a new Result.
 // Play: https://go.dev/play/p/Ud5QjZOqg-7
 func (r Result[T]) FlatMap(mapper func(value T) Result[T]) Result[T] {

--- a/result_test.go
+++ b/result_test.go
@@ -190,6 +190,14 @@ func TestResultMapErr(t *testing.T) {
 	is.Equal(Result[int]{value: 42, isErr: false, err: nil}, opt2)
 }
 
+func TestResultErrContext(t *testing.T) {
+	is := assert.New(t)
+
+	opt := Err[int](assert.AnError).ErrContext("Oh bananas")
+
+	is.Equal(Result[int]{value: 0, isErr: true, err: errors.New("Oh bananas\n\nOriginal Error:\nassert.AnError general error for testing")}, opt)
+}
+
 func TestResultFlatMap(t *testing.T) {
 	is := assert.New(t)
 


### PR DESCRIPTION
This feature proposal is inspired by the extremely popular Rust library, [`anyhow`](https://lib.rs/crates/anyhow). One of the features of `anyhow` is that you can attach context to errors to assist in troubleshooting.

For instance, an error like `No such file or directory` can be hard to debug without more context about what higher level step the application was in the middle of.

The following code with `anyhow`...

```rust
use anyhow::{Context, Result};

fn main() -> Result<()> {
    ...
    it.detach().context("Failed to detach the important thing")?;

    let content = std::fs::read(path)
        .with_context(|| format!("Failed to read instrs from {}", path))?;
    ...
}
```

Results in the following error:

```txt
Error: Failed to read instrs from ./path/to/instrs.json

Caused by:
    No such file or directory (os error 2)
```