### PR TITLE
Option: Support omitempty

### DIFF
--- a/fold_example_test.go
+++ b/fold_example_test.go
@@ -44,8 +44,8 @@ func ExampleFold_either() {
 }
 
 func ExampleFold_option() {
-	option1 := Option[int]{isPresent: true, value: 42}
-	option2 := Option[int]{isPresent: false}
+	option1 := Option[int]{42}
+	option2 := Option[int]{}
 
 	successFunc := func(val int) string {
 		return fmt.Sprintf("Success with value %d", val)

--- a/option_go122.go
+++ b/option_go122.go
@@ -14,8 +14,7 @@ func (o *Option[T]) scanConvertValue(src any) error {
 	// Value type than the one we expect here.
 	var st sql.Null[T]
 	if err := st.Scan(src); err == nil {
-		o.isPresent = true
-		o.value = st.V
+		*o = append(*o, st.V)
 		return nil
 	}
 	return fmt.Errorf("failed to scan Option[T]")


### PR DESCRIPTION
This requires changing the underlying type, which *may* be a breaking change.

AFAICT there isn't any way to do this with the struct based type, but can be done with a slice type (or a map, but maps are heavier weight, so chose slice).

When the slice is empty (len == 0) it is considered absent, when it has an item it is considered present.

This also allows for creating a value via:

`Option[T]{value}`

Any values appended to the slice after the first are ignored.