### PR TITLE
Fix test to use IsSome() instead of IsPresent()

### DIFF
--- a/option_test.go
+++ b/option_test.go
@@ -67,8 +67,8 @@ func TestOptionIsPresent(t *testing.T) {
 func TestOptionIsSome(t *testing.T) {
 	is := assert.New(t)
 
-	is.True(Some(42).IsPresent())
-	is.False(None[int]().IsPresent())
+	is.True(Some(42).IsSome())
+	is.False(None[int]().IsSome())
 }
 
 func TestOptionIsAbsent(t *testing.T) {


### PR DESCRIPTION
close https://github.com/samber/mo/issues/82

Updates TestOptionIsSome to call IsSome() method correctly.