### PR TITLE
feat(either): add GobEncode/GobDecode and MarshalBinary/UnmarshalBinary

### DIFF
--- a/either.go
+++ b/either.go
@@ -1,6 +1,11 @@
 package mo
 
-import "fmt"
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+)
 
 var errEitherShouldBeLeftOrRight = fmt.Errorf("either should be Left or Right")
 var errEitherMissingLeftValue = fmt.Errorf("no such Left value")
@@ -186,4 +191,58 @@ func (e Either[L, R]) rightValue() R {
 //nolint:unused
 func (e Either[L, R]) hasLeftValue() bool {
 	return e.isLeft
+}
+
+// MarshalBinary encodes Either into binary form.
+func (e Either[L, R]) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	if e.isLeft {
+		if err := enc.Encode(e.left); err != nil {
+			return []byte{}, err
+		}
+		return append([]byte{1}, buf.Bytes()...), nil
+	}
+
+	if err := enc.Encode(e.right); err != nil {
+		return []byte{}, err
+	}
+	return append([]byte{0}, buf.Bytes()...), nil
+}
+
+// UnmarshalBinary decodes Either from binary form.
+func (e *Either[L, R]) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("Either[L, R].UnmarshalBinary: no data")
+	}
+
+	buf := bytes.NewBuffer(data[1:])
+	dec := gob.NewDecoder(buf)
+
+	if data[0] == 1 {
+		if err := dec.Decode(&e.left); err != nil {
+			return err
+		}
+		e.isLeft = true
+		e.right = empty[R]()
+		return nil
+	}
+
+	if err := dec.Decode(&e.right); err != nil {
+		return err
+	}
+	e.isLeft = false
+	e.left = empty[L]()
+	return nil
+}
+
+// GobEncode implements the gob.GobEncoder interface.
+func (e Either[L, R]) GobEncode() ([]byte, error) {
+	return e.MarshalBinary()
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (e *Either[L, R]) GobDecode(data []byte) error {
+	return e.UnmarshalBinary(data)
 }

--- a/either_test.go
+++ b/either_test.go
@@ -251,3 +251,38 @@ func TestEitherFoldFailure(t *testing.T) {
 
 	is.Equal(expected, folded)
 }
+
+func TestEitherGobEncode(t *testing.T) {
+	is := assert.New(t)
+
+	left := Left[int, string](42)
+	right := Right[int, string]("foobar")
+
+	bin1, err1 := left.GobEncode()
+	bin2, err2 := right.GobEncode()
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Equal(byte(1), bin1[0]) // isLeft flag
+	is.Equal(byte(0), bin2[0]) // isRight flag
+}
+
+func TestEitherGobDecode(t *testing.T) {
+	is := assert.New(t)
+
+	original1 := Left[int, string](42)
+	original2 := Right[int, string]("foobar")
+
+	bin1, _ := original1.GobEncode()
+	bin2, _ := original2.GobEncode()
+
+	var decoded1, decoded2 Either[int, string]
+
+	err1 := decoded1.GobDecode(bin1)
+	err2 := decoded2.GobDecode(bin2)
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Equal(original1, decoded1)
+	is.Equal(original2, decoded2)
+}


### PR DESCRIPTION
Contributes to #99

Implements binary serialization for `Either[L, R]`, mirroring the existing encoding support on `Option[T]`.

## Changes                                                                                                                                             

- `MarshalBinary` / `UnmarshalBinary` — implements `encoding.BinaryMarshaler` / `encoding.BinaryUnmarshaler`                                           
- `GobEncode` / `GobDecode` — implements `gob.GobEncoder` / `gob.GobDecoder`, delegating to the above

## Encoding format

- `[1][gob-encoded value]` for Left                                                                                                                    
- `[0][gob-encoded value]` for Right

## Tests

Round-trip coverage for both Left and Right variants via `TestEitherGobEncode` and `TestEitherGobDecode`.