### PR TITLE
feat(either3,either4,either5): add GobEncode/GobDecode and MarshalBinary/UnmarshalBinary

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,2 @@
 github: [samber]
+ko_fi: samuelberthe

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,20 +15,20 @@ permissions:
   security-events: write
 
 jobs:
-  govulncheck:
-    name: govulncheck
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+  # govulncheck:
+  #   name: govulncheck
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #     - uses: actions/setup-go@v6
 
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+  #     - name: Install govulncheck
+  #       run: go install golang.org/x/vuln/cmd/govulncheck@latest
 
-      - name: govulncheck
-        run: govulncheck ./...
+  #     - name: govulncheck
+  #       run: govulncheck ./...
 
   bearer:
     name: bearer

--- a/either3.go
+++ b/either3.go
@@ -1,6 +1,11 @@
 package mo
 
-import "fmt"
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+)
 
 const (
 	either3ArgId1 = iota
@@ -220,4 +225,75 @@ func (e Either3[T1, T2, T3]) MapArg3(mapper func(T3) Either3[T1, T2, T3]) Either
 	}
 
 	return e
+}
+
+// MarshalBinary encodes Either3 into binary form.
+func (e Either3[T1, T2, T3]) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	switch e.argId {
+	case either3ArgId1:
+		if err := enc.Encode(e.arg1); err != nil {
+			return []byte{}, err
+		}
+	case either3ArgId2:
+		if err := enc.Encode(e.arg2); err != nil {
+			return []byte{}, err
+		}
+	case either3ArgId3:
+		if err := enc.Encode(e.arg3); err != nil {
+			return []byte{}, err
+		}
+	default:
+		return []byte{}, errEither3InvalidArgumentId
+	}
+	return append([]byte{byte(e.argId)}, buf.Bytes()...), nil
+}
+
+// UnmarshalBinary decodes Either3 from binary form.
+func (e *Either3[T1, T2, T3]) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("Either3[T1, T2, T3].UnmarshalBinary: no data")
+	}
+
+	buf := bytes.NewBuffer(data[1:])
+	dec := gob.NewDecoder(buf)
+
+	switch int8(data[0]) {
+	case either3ArgId1:
+		if err := dec.Decode(&e.arg1); err != nil {
+			return err
+		}
+		e.argId = either3ArgId1
+		e.arg2 = empty[T2]()
+		e.arg3 = empty[T3]()
+	case either3ArgId2:
+		if err := dec.Decode(&e.arg2); err != nil {
+			return err
+		}
+		e.argId = either3ArgId2
+		e.arg1 = empty[T1]()
+		e.arg3 = empty[T3]()
+	case either3ArgId3:
+		if err := dec.Decode(&e.arg3); err != nil {
+			return err
+		}
+		e.argId = either3ArgId3
+		e.arg1 = empty[T1]()
+		e.arg2 = empty[T2]()
+	default:
+		return errEither3InvalidArgumentId
+	}
+	return nil
+}
+
+// GobEncode implements the gob.GobEncoder interface.
+func (e Either3[T1, T2, T3]) GobEncode() ([]byte, error) {
+	return e.MarshalBinary()
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (e *Either3[T1, T2, T3]) GobDecode(data []byte) error {
+	return e.UnmarshalBinary(data)
 }

--- a/either3_test.go
+++ b/either3_test.go
@@ -295,3 +295,47 @@ func TestEither3MapArg(t *testing.T) {
 	})
 	is.Equal(NewEither3Arg3[int, bool, float64](2.1), result3_3)
 }
+
+func TestEither3GobEncode(t *testing.T) {
+	is := assert.New(t)
+
+	arg1 := NewEither3Arg1[int, bool, float64](42)
+	arg2 := NewEither3Arg2[int, bool, float64](true)
+	arg3 := NewEither3Arg3[int, bool, float64](1.5)
+
+	bin1, err1 := arg1.GobEncode()
+	bin2, err2 := arg2.GobEncode()
+	bin3, err3 := arg3.GobEncode()
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Nil(err3)
+	is.Equal(byte(either3ArgId1), bin1[0])
+	is.Equal(byte(either3ArgId2), bin2[0])
+	is.Equal(byte(either3ArgId3), bin3[0])
+}
+
+func TestEither3GobDecode(t *testing.T) {
+	is := assert.New(t)
+
+	original1 := NewEither3Arg1[int, bool, float64](42)
+	original2 := NewEither3Arg2[int, bool, float64](true)
+	original3 := NewEither3Arg3[int, bool, float64](1.5)
+
+	bin1, _ := original1.GobEncode()
+	bin2, _ := original2.GobEncode()
+	bin3, _ := original3.GobEncode()
+
+	var decoded1, decoded2, decoded3 Either3[int, bool, float64]
+
+	err1 := decoded1.GobDecode(bin1)
+	err2 := decoded2.GobDecode(bin2)
+	err3 := decoded3.GobDecode(bin3)
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Nil(err3)
+	is.Equal(original1, decoded1)
+	is.Equal(original2, decoded2)
+	is.Equal(original3, decoded3)
+}

--- a/either4.go
+++ b/either4.go
@@ -1,6 +1,11 @@
 package mo
 
-import "fmt"
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+)
 
 const (
 	either4ArgId1 = iota
@@ -282,4 +287,90 @@ func (e Either4[T1, T2, T3, T4]) MapArg4(mapper func(T4) Either4[T1, T2, T3, T4]
 	}
 
 	return e
+}
+
+// MarshalBinary encodes Either4 into binary form.
+func (e Either4[T1, T2, T3, T4]) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	switch e.argId {
+	case either4ArgId1:
+		if err := enc.Encode(e.arg1); err != nil {
+			return []byte{}, err
+		}
+	case either4ArgId2:
+		if err := enc.Encode(e.arg2); err != nil {
+			return []byte{}, err
+		}
+	case either4ArgId3:
+		if err := enc.Encode(e.arg3); err != nil {
+			return []byte{}, err
+		}
+	case either4ArgId4:
+		if err := enc.Encode(e.arg4); err != nil {
+			return []byte{}, err
+		}
+	default:
+		return []byte{}, errEither4InvalidArgumentId
+	}
+	return append([]byte{byte(e.argId)}, buf.Bytes()...), nil
+}
+
+// UnmarshalBinary decodes Either4 from binary form.
+func (e *Either4[T1, T2, T3, T4]) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("Either4[T1, T2, T3, T4].UnmarshalBinary: no data")
+	}
+
+	buf := bytes.NewBuffer(data[1:])
+	dec := gob.NewDecoder(buf)
+
+	switch int8(data[0]) {
+	case either4ArgId1:
+		if err := dec.Decode(&e.arg1); err != nil {
+			return err
+		}
+		e.argId = either4ArgId1
+		e.arg2 = empty[T2]()
+		e.arg3 = empty[T3]()
+		e.arg4 = empty[T4]()
+	case either4ArgId2:
+		if err := dec.Decode(&e.arg2); err != nil {
+			return err
+		}
+		e.argId = either4ArgId2
+		e.arg1 = empty[T1]()
+		e.arg3 = empty[T3]()
+		e.arg4 = empty[T4]()
+	case either4ArgId3:
+		if err := dec.Decode(&e.arg3); err != nil {
+			return err
+		}
+		e.argId = either4ArgId3
+		e.arg1 = empty[T1]()
+		e.arg2 = empty[T2]()
+		e.arg4 = empty[T4]()
+	case either4ArgId4:
+		if err := dec.Decode(&e.arg4); err != nil {
+			return err
+		}
+		e.argId = either4ArgId4
+		e.arg1 = empty[T1]()
+		e.arg2 = empty[T2]()
+		e.arg3 = empty[T3]()
+	default:
+		return errEither4InvalidArgumentId
+	}
+	return nil
+}
+
+// GobEncode implements the gob.GobEncoder interface.
+func (e Either4[T1, T2, T3, T4]) GobEncode() ([]byte, error) {
+	return e.MarshalBinary()
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (e *Either4[T1, T2, T3, T4]) GobDecode(data []byte) error {
+	return e.UnmarshalBinary(data)
 }

--- a/either4_test.go
+++ b/either4_test.go
@@ -451,3 +451,56 @@ func TestEither4MapArg(t *testing.T) {
 	})
 	is.Equal(NewEither4Arg4[int, bool, float64, string]("Bye"), result4_4)
 }
+
+func TestEither4GobEncode(t *testing.T) {
+	is := assert.New(t)
+
+	arg1 := NewEither4Arg1[int, bool, float64, string](42)
+	arg2 := NewEither4Arg2[int, bool, float64, string](true)
+	arg3 := NewEither4Arg3[int, bool, float64, string](1.5)
+	arg4 := NewEither4Arg4[int, bool, float64, string]("hello")
+
+	bin1, err1 := arg1.GobEncode()
+	bin2, err2 := arg2.GobEncode()
+	bin3, err3 := arg3.GobEncode()
+	bin4, err4 := arg4.GobEncode()
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Nil(err3)
+	is.Nil(err4)
+	is.Equal(byte(either4ArgId1), bin1[0])
+	is.Equal(byte(either4ArgId2), bin2[0])
+	is.Equal(byte(either4ArgId3), bin3[0])
+	is.Equal(byte(either4ArgId4), bin4[0])
+}
+
+func TestEither4GobDecode(t *testing.T) {
+	is := assert.New(t)
+
+	original1 := NewEither4Arg1[int, bool, float64, string](42)
+	original2 := NewEither4Arg2[int, bool, float64, string](true)
+	original3 := NewEither4Arg3[int, bool, float64, string](1.5)
+	original4 := NewEither4Arg4[int, bool, float64, string]("hello")
+
+	bin1, _ := original1.GobEncode()
+	bin2, _ := original2.GobEncode()
+	bin3, _ := original3.GobEncode()
+	bin4, _ := original4.GobEncode()
+
+	var decoded1, decoded2, decoded3, decoded4 Either4[int, bool, float64, string]
+
+	err1 := decoded1.GobDecode(bin1)
+	err2 := decoded2.GobDecode(bin2)
+	err3 := decoded3.GobDecode(bin3)
+	err4 := decoded4.GobDecode(bin4)
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Nil(err3)
+	is.Nil(err4)
+	is.Equal(original1, decoded1)
+	is.Equal(original2, decoded2)
+	is.Equal(original3, decoded3)
+	is.Equal(original4, decoded4)
+}

--- a/either5.go
+++ b/either5.go
@@ -1,6 +1,11 @@
 package mo
 
-import "fmt"
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+)
 
 const (
 	either5ArgId1 = iota
@@ -344,4 +349,107 @@ func (e Either5[T1, T2, T3, T4, T5]) MapArg5(mapper func(T5) Either5[T1, T2, T3,
 	}
 
 	return e
+}
+
+// MarshalBinary encodes Either5 into binary form.
+func (e Either5[T1, T2, T3, T4, T5]) MarshalBinary() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+
+	switch e.argId {
+	case either5ArgId1:
+		if err := enc.Encode(e.arg1); err != nil {
+			return []byte{}, err
+		}
+	case either5ArgId2:
+		if err := enc.Encode(e.arg2); err != nil {
+			return []byte{}, err
+		}
+	case either5ArgId3:
+		if err := enc.Encode(e.arg3); err != nil {
+			return []byte{}, err
+		}
+	case either5ArgId4:
+		if err := enc.Encode(e.arg4); err != nil {
+			return []byte{}, err
+		}
+	case either5ArgId5:
+		if err := enc.Encode(e.arg5); err != nil {
+			return []byte{}, err
+		}
+	default:
+		return []byte{}, errEither5InvalidArgumentId
+	}
+	return append([]byte{byte(e.argId)}, buf.Bytes()...), nil
+}
+
+// UnmarshalBinary decodes Either5 from binary form.
+func (e *Either5[T1, T2, T3, T4, T5]) UnmarshalBinary(data []byte) error {
+	if len(data) == 0 {
+		return errors.New("Either5[T1, T2, T3, T4, T5].UnmarshalBinary: no data")
+	}
+
+	buf := bytes.NewBuffer(data[1:])
+	dec := gob.NewDecoder(buf)
+
+	switch int8(data[0]) {
+	case either5ArgId1:
+		if err := dec.Decode(&e.arg1); err != nil {
+			return err
+		}
+		e.argId = either5ArgId1
+		e.arg2 = empty[T2]()
+		e.arg3 = empty[T3]()
+		e.arg4 = empty[T4]()
+		e.arg5 = empty[T5]()
+	case either5ArgId2:
+		if err := dec.Decode(&e.arg2); err != nil {
+			return err
+		}
+		e.argId = either5ArgId2
+		e.arg1 = empty[T1]()
+		e.arg3 = empty[T3]()
+		e.arg4 = empty[T4]()
+		e.arg5 = empty[T5]()
+	case either5ArgId3:
+		if err := dec.Decode(&e.arg3); err != nil {
+			return err
+		}
+		e.argId = either5ArgId3
+		e.arg1 = empty[T1]()
+		e.arg2 = empty[T2]()
+		e.arg4 = empty[T4]()
+		e.arg5 = empty[T5]()
+	case either5ArgId4:
+		if err := dec.Decode(&e.arg4); err != nil {
+			return err
+		}
+		e.argId = either5ArgId4
+		e.arg1 = empty[T1]()
+		e.arg2 = empty[T2]()
+		e.arg3 = empty[T3]()
+		e.arg5 = empty[T5]()
+	case either5ArgId5:
+		if err := dec.Decode(&e.arg5); err != nil {
+			return err
+		}
+		e.argId = either5ArgId5
+		e.arg1 = empty[T1]()
+		e.arg2 = empty[T2]()
+		e.arg3 = empty[T3]()
+		e.arg4 = empty[T4]()
+	default:
+		return errEither5InvalidArgumentId
+	}
+	return nil
+}
+
+// GobEncode implements the gob.GobEncoder interface.
+func (e Either5[T1, T2, T3, T4, T5]) GobEncode() ([]byte, error) {
+	return e.MarshalBinary()
+}
+
+// GobDecode implements the gob.GobDecoder interface.
+func (e *Either5[T1, T2, T3, T4, T5]) GobDecode(data []byte) error {
+	return e.UnmarshalBinary(data)
 }

--- a/either5_test.go
+++ b/either5_test.go
@@ -645,3 +645,65 @@ func TestEither5MapArg(t *testing.T) {
 	})
 	is.Equal(NewEither5Arg5[int, bool, float64, string, byte](10), result5_5)
 }
+
+func TestEither5GobEncode(t *testing.T) {
+	is := assert.New(t)
+
+	arg1 := NewEither5Arg1[int, bool, float64, string, byte](42)
+	arg2 := NewEither5Arg2[int, bool, float64, string, byte](true)
+	arg3 := NewEither5Arg3[int, bool, float64, string, byte](1.5)
+	arg4 := NewEither5Arg4[int, bool, float64, string, byte]("hello")
+	arg5 := NewEither5Arg5[int, bool, float64, string, byte](byte(5))
+
+	bin1, err1 := arg1.GobEncode()
+	bin2, err2 := arg2.GobEncode()
+	bin3, err3 := arg3.GobEncode()
+	bin4, err4 := arg4.GobEncode()
+	bin5, err5 := arg5.GobEncode()
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Nil(err3)
+	is.Nil(err4)
+	is.Nil(err5)
+	is.Equal(byte(either5ArgId1), bin1[0])
+	is.Equal(byte(either5ArgId2), bin2[0])
+	is.Equal(byte(either5ArgId3), bin3[0])
+	is.Equal(byte(either5ArgId4), bin4[0])
+	is.Equal(byte(either5ArgId5), bin5[0])
+}
+
+func TestEither5GobDecode(t *testing.T) {
+	is := assert.New(t)
+
+	original1 := NewEither5Arg1[int, bool, float64, string, byte](42)
+	original2 := NewEither5Arg2[int, bool, float64, string, byte](true)
+	original3 := NewEither5Arg3[int, bool, float64, string, byte](1.5)
+	original4 := NewEither5Arg4[int, bool, float64, string, byte]("hello")
+	original5 := NewEither5Arg5[int, bool, float64, string, byte](byte(5))
+
+	bin1, _ := original1.GobEncode()
+	bin2, _ := original2.GobEncode()
+	bin3, _ := original3.GobEncode()
+	bin4, _ := original4.GobEncode()
+	bin5, _ := original5.GobEncode()
+
+	var decoded1, decoded2, decoded3, decoded4, decoded5 Either5[int, bool, float64, string, byte]
+
+	err1 := decoded1.GobDecode(bin1)
+	err2 := decoded2.GobDecode(bin2)
+	err3 := decoded3.GobDecode(bin3)
+	err4 := decoded4.GobDecode(bin4)
+	err5 := decoded5.GobDecode(bin5)
+
+	is.Nil(err1)
+	is.Nil(err2)
+	is.Nil(err3)
+	is.Nil(err4)
+	is.Nil(err5)
+	is.Equal(original1, decoded1)
+	is.Equal(original2, decoded2)
+	is.Equal(original3, decoded3)
+	is.Equal(original4, decoded4)
+	is.Equal(original5, decoded5)
+}


### PR DESCRIPTION
Closes #99

Extends binary serialization support from `Either[L, R]` (PR #100) to `Either3`, `Either4`, and `Either5`.

## Changes

- `MarshalBinary` / `UnmarshalBinary` — implements `encoding.BinaryMarshaler` / `encoding.BinaryUnmarshaler`
- `GobEncode` / `GobDecode` — implements `gob.GobEncoder` / `gob.GobDecoder`, delegating to the above

## Encoding format

- `[argId][gob-encoded value]` where `argId` is `0` for Arg1, `1` for Arg2, etc.