### PR TITLE
fix: State.Put ignores its argument due to variable shadowing

### DIFF
--- a/state.go
+++ b/state.go
@@ -43,10 +43,10 @@ func (s State[S, A]) Modify(f func(state S) S) State[S, A] {
 }
 
 // Put set the state.
-func (s State[S, A]) Put(state S) State[S, A] {
+func (s State[S, A]) Put(newState S) State[S, A] {
 	return State[S, A]{
-		run: func(state S) (A, S) {
-			return empty[A](), state
+		run: func(_ S) (A, S) {
+			return empty[A](), newState
 		},
 	}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -1,0 +1,90 @@
+package mo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewState(t *testing.T) {
+	is := assert.New(t)
+
+	// A computation that returns the current state doubled as the result and
+	// increments the state.
+	s := NewState(func(state int) (int, int) {
+		return state * 2, state + 1
+	})
+
+	result, newState := s.Run(10)
+	is.Equal(20, result)
+	is.Equal(11, newState)
+}
+
+func TestReturnState(t *testing.T) {
+	is := assert.New(t)
+
+	// ReturnState yields the given value and leaves the state untouched.
+	s := ReturnState[string](42)
+
+	result, newState := s.Run("unchanged")
+	is.Equal(42, result)
+	is.Equal("unchanged", newState)
+}
+
+func TestStateRun(t *testing.T) {
+	is := assert.New(t)
+
+	s := NewState(func(state int) (string, int) {
+		return "value", state + 100
+	})
+
+	result, newState := s.Run(1)
+	is.Equal("value", result)
+	is.Equal(101, newState)
+}
+
+func TestStateGet(t *testing.T) {
+	is := assert.New(t)
+
+	s := NewState(func(state int) (string, int) {
+		return "ignored", state
+	})
+
+	// Get returns the current state as both the result and the state.
+	getter := s.Get()
+	result, newState := getter.Run(7)
+	is.Equal(7, result)
+	is.Equal(7, newState)
+}
+
+func TestStateModify(t *testing.T) {
+	is := assert.New(t)
+
+	s := NewState(func(state int) (string, int) {
+		return "ignored", state
+	})
+
+	// Modify applies f to the state and yields the zero value of A.
+	modified := s.Modify(func(state int) int {
+		return state * 10
+	})
+
+	result, newState := modified.Run(5)
+	is.Equal("", result) // zero value of string
+	is.Equal(50, newState)
+}
+
+func TestStatePut(t *testing.T) {
+	is := assert.New(t)
+
+	s := NewState(func(state int) (string, int) {
+		return "ignored", state
+	})
+
+	// Put replaces the state and yields the zero value of A.
+	put := s.Put(99)
+
+	result, newState := put.Run(1)
+	is.Equal("", result) // zero value of string
+	is.Equal(99, newState)
+}


### PR DESCRIPTION
## Problem

`State.Put` is documented as *"set the state"*, but it is currently a no-op:

```go
func (s State[S, A]) Put(state S) State[S, A] {
    return State[S, A]{
        run: func(state S) (A, S) { // this state parameter shadows Put's argument
            return empty[A](), state
        },
    }
}
```

The inner `run` closure declares its own `state` parameter, which **shadows** the `state` argument passed to `Put`. So the closure returns the incoming run-time state unchanged, and the value passed to `Put` is silently discarded:

```go
s.Put(99).Run(1) // returns ("", 1) — expected ("", 99)
```

## Fix

Rename `Put`'s parameter to `newState` and ignore the run-time state in the closure, so `Put` sets the state as documented.

## Tests

`state.go` had no test file at all. This PR adds `state_test.go` covering the whole State monad — `NewState`, `ReturnState`, `Run`, `Get`, `Modify`, and `Put` — bringing the file to 100% coverage. The `Put` test pins the corrected behaviour so it can't regress.

- `go test ./...` passes
- `gofmt` and `go vet` are clean