### PR TITLE
Do not panic in Option.IsZero when T is an interface

### DIFF
--- a/option.go
+++ b/option.go
@@ -257,7 +257,9 @@ func (o Option[T]) IsZero() bool {
 		return v.IsZero()
 	}
 
-	return reflect.ValueOf(o.value).IsZero()
+	// a nil interface yields an invalid reflect.Value, on which IsZero panics
+	rv := reflect.ValueOf(o.value)
+	return !rv.IsValid() || rv.IsZero()
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.

--- a/option_test.go
+++ b/option_test.go
@@ -736,3 +736,19 @@ func TestOption_Equal(t *testing.T) {
 	close(ch1)
 	close(ch2)
 }
+
+func TestOptionIsZero(t *testing.T) {
+	is := assert.New(t)
+
+	is.True(None[int]().IsZero())
+	is.True(Some(0).IsZero())
+	is.False(Some(42).IsZero())
+	is.True(Some[*int](nil).IsZero())
+
+	// T is an interface type: a nil value is the zero value of T.
+	is.True(None[any]().IsZero())
+	is.True(Some[any](nil).IsZero())
+	is.False(Some[any](42).IsZero())
+	is.True(Some[error](nil).IsZero())
+	is.False(Some[error](errOptionNoSuchElement).IsZero())
+}


### PR DESCRIPTION
`Option[T].IsZero` ends with:

```go
return reflect.ValueOf(o.value).IsZero()   // option.go:260
```

When `T` is an interface type holding `nil`, `reflect.ValueOf` returns the **invalid** `reflect.Value`, and `Value.IsZero` panics on it.

```go
type S struct {
	V mo.Option[any] `json:"v,omitzero"`
}
json.Marshal(S{V: mo.Some[any](nil)})
```

```
IsPresent: true
PANIC: reflect: call of reflect.Value.IsZero on zero Value
```

The consumer is not hypothetical -- it is the one the method was written for. `option.go:249` says:

> `// IsZero assists `omitzero` tag introduced in Go 1.24`

and `option.go:214` points users at `omitzero` as the current best workaround. So any struct with an `Option[any]`, `Option[error]` or `Option[fmt.Stringer]` field tagged `omitzero` takes down the whole `json.Marshal`, not just that field.

## Two functions in this same file already guard it

- `Equal` (`option.go:377`): `if t := reflect.TypeOf(o.value); t != nil {`
- `EmptyableToOption` (`option.go:50`): `reflect.ValueOf(&value).Elem().IsZero()`, which is always valid

`IsZero` is the odd one out. `git log -L 249,261:option.go` shows the line arrived with PR #84 (the `Equal` work) and no test -- the nil guard that went into `Equal` was not carried across.

## The fix

Check `IsValid` before `IsZero`. Three lines.

I did **not** use `EmptyableToOption`'s `reflect.ValueOf(&o.value).Elem()` form even though it would also work: taking the address of the receiver's field risks a heap escape, and #110 was explicitly about reducing allocations on these paths. After the change `BenchmarkOptionIsZero` reports `Some 11.01 ns/op, 0 allocs/op` and `None 1.214 ns/op, 0 allocs/op`.

## Behaviour change

For every non-interface `T`, `rv.IsValid()` is unconditionally true, so the result is identical. The only change is that interface instantiations return a value instead of panicking. **No existing test row changes** -- `IsZero` had no test coverage at all before this (`grep -c IsZero option_test.go` was 0), which is why the panic went unnoticed.

## Verification

`go test -race -count=1 ./...` -- all 8 packages ok. `go vet ./...` clean. The Makefile's lint line verbatim, `golangci-lint run --timeout 60s --max-same-issues 50 ./...` -- **0 issues**. `gofmt -l .` flags `option/transforms_test.go` and `result/transforms_test.go` both before and after; neither is in my diff.

Mutation checks:

| mutation | result |
|---|---|
| revert to `reflect.ValueOf(o.value).IsZero()` | fails, panics |
| return only `!rv.IsValid()`, dropping the `IsZero` half | fails |
| invert to `rv.IsValid() && rv.IsZero()` | fails |
| use `Equal`'s form, `if reflect.TypeOf(o.value) == nil { return true }` | **passes** |

The last one is deliberate: it is the guard you already wrote in `Equal`, and its passing shows the test pins "a nil interface is zero" rather than the particular expression I used. If you would rather the two functions look identical, that form is a fine substitute.

## What I did not change

The `zeroer` fast path just above (`option.go:255`). `Some[any]((*time.Time)(nil))` satisfies `zeroer` through the pointer method set and then nil-derefs inside the user's own `IsZero`. That is a different failure with a different owner, and deciding what `mo` should do about it would mean picking a semantic the package does not state anywhere -- happy to open a separate issue if you want it discussed.

---

Disclosure: AI-assisted. I found and prepared this with an AI assistant, and I ran and verified everything above myself.
